### PR TITLE
:zap: Enable websocket proxy in nginx

### DIFF
--- a/default
+++ b/default
@@ -18,6 +18,18 @@
 ##
 # Default server configuration
 #
+
+## Websocket Config Start
+map $http_upgrade $connection_upgrade {
+        default upgrade;
+        '' close;
+}
+
+upstream websocket {
+        server localhost:8080;
+}
+## Websocket Config End
+    
 server {
         listen 80 default_server;
                 # try_files $uri $uri/ =404;
@@ -55,6 +67,12 @@ server {
                 proxy_set_header X-Real-IP $remote_addr;
                 proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
                 proxy_set_header X-Forwarded-Proto $scheme;
+                
+                ## Websocket Config Start
+                proxy_http_version 1.1;
+                proxy_set_header Upgrade $http_upgrade;
+                proxy_set_header Connection $connection_upgrade;
+                ## Websocket Config End
         }
 
         # pass PHP scripts to FastCGI server


### PR DESCRIPTION
Use websocket instead of ajax in Socket.io reduce client CPU usage.